### PR TITLE
Added basic integration with RemoteTech.

### DIFF
--- a/GameData/Kerbalism/Patches/z_RemoteTech.cfg
+++ b/GameData/Kerbalism/Patches/z_RemoteTech.cfg
@@ -1,0 +1,27 @@
+// ============================================================================
+// Remove Antenna module and Malfunctions from all antennas if RemoteTech is enabled.
+// ============================================================================
+
+@PART[shortAntenna]:FOR[RemoteTech]
+{
+  %MODULE[ModuleRTAntenna] {
+    %Mode0OmniRange = 0
+    %Mode1OmniRange = 250000
+    %MaxQ = 6000
+    %EnergyCost = 0.01
+    
+    %DeployFxModules = 0
+    
+    %TRANSMITTER {
+      %PacketInterval = 0.3
+      %PacketSize = 2
+      %PacketResourceCost = 15.0
+    }
+  }
+}
+
+@PART[*]:HAS[@MODULE[Antenna]]:AFTER[RemoteTech]
+{
+  !MODULE[Antenna] {}
+  !MODULE[Malfunctions] {}
+}

--- a/src/Kerbalism.csproj
+++ b/src/Kerbalism.csproj
@@ -84,6 +84,7 @@
     <Compile Include="EVA.cs" />
     <Compile Include="GravityRing.cs" />
     <Compile Include="Info.cs" />
+    <Compile Include="RemoteTech.cs" />
     <Compile Include="SCANsat.cs" />
     <Compile Include="Hooks.cs" />
     <Compile Include="Malfunction.cs" />
@@ -109,6 +110,6 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>xcopy Z:\kspmod\Kerbalism\Kerbalism\obj\Release\Kerbalism.dll C:\Games\KSP\GameData\Kerbalism\ /y</PostBuildEvent>
+    <PostBuildEvent>xcopy $(ProjectDir)obj\Release\Kerbalism.dll C:\Games\KSP\GameData\Kerbalism\ /y</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/src/Monitor.cs
+++ b/src/Monitor.cs
@@ -441,7 +441,10 @@ public class Monitor
     GUILayout.Label(indicator_ec(v), icon_style);
     GUILayout.Label(indicator_supplies(v, vi), icon_style);
     GUILayout.Label(indicator_reliability(v), icon_style);
-    GUILayout.Label(indicator_signal(v), icon_style);
+    if (!RemoteTech.isEnabled())
+    {
+      GUILayout.Label(indicator_signal(v), icon_style);
+    }
     GUILayout.EndHorizontal();
     if (Lib.IsClicked(1)) Info.Toggle(v);
 

--- a/src/Planner.cs
+++ b/src/Planner.cs
@@ -436,7 +436,10 @@ public class Planner
     ec.consumed += oxygen.scrubber_cost;
 
     // include relay cost for the best relay antenna
-    ec.consumed += signal.relay_cost;
+    if (!RemoteTech.isEnabled())
+    {
+      ec.consumed += signal.relay_cost;
+    }
 
     // finally, calculate life expectancy of ec
     ec.life_expectancy_sunlight = ec.storage / Math.Max(ec.consumed - ec.generated_sunlight, 0.0);
@@ -604,7 +607,10 @@ public class Planner
       qol.time_to_instability = bonus / Settings.StressedDegradationRate;
       List<string> factors = new List<string>();
       if (crew.count > 1) factors.Add("not-alone");
-      if (signal.range > 0.0) factors.Add("call-home");
+      if (!RemoteTech.isEnabled())
+      {
+        if (signal.range > 0.0) factors.Add("call-home");
+      }
       if (env.landed) factors.Add("firm-ground");
       if (factors.Count == 0) factors.Add("none");
       qol.factors = String.Join(", ", factors.ToArray());
@@ -690,7 +696,10 @@ public class Planner
     double antenna_redundancy = signal.second_best_range > 0.0 ? signal.second_best_range / signal.range : 0.0;
     List<string> redundancies = new List<string>();
     if (ec_redundancy >= 0.5) redundancies.Add("ec");
-    if (antenna_redundancy >= 0.99) redundancies.Add("antenna");
+    if (!RemoteTech.isEnabled())
+    {
+      if (antenna_redundancy >= 0.99) redundancies.Add("antenna");
+    }
     if (redundancies.Count == 0) redundancies.Add("none");
     reliability.redundancy = String.Join(", ", redundancies.ToArray());
 
@@ -1024,7 +1033,9 @@ public class Planner
         // render
         render_radiation(radiation, env, crew);
         render_reliability(reliability, crew);
-        render_signal(signal, env, crew);
+        if (!RemoteTech.isEnabled()) {
+            render_signal(signal, env, crew);
+        }
         render_environment(env);
       }
     }

--- a/src/RemoteTech.cs
+++ b/src/RemoteTech.cs
@@ -1,0 +1,47 @@
+﻿// ===================================================================================================================
+// Utility functions to interact with RemoteTech
+// ===================================================================================================================
+
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using UnityEngine;
+
+
+namespace KERBALISM
+{
+
+  public static class RemoteTech
+  {
+    // store initialized flag, for lazy initialization
+    static bool initialized = false;
+
+    // cache the result of the check here
+    static bool enabled = false;
+
+    // check if RemoteTech is loaded
+    public static bool isEnabled()
+    {
+      // search for compatible SCANsat assembly
+      if (!initialized)
+      {
+        foreach (var a in AssemblyLoader.loadedAssemblies)
+        {
+          if (a.name == "RemoteTech")
+          {
+            enabled = true;
+            break;
+          }
+        }
+        initialized = true;
+      }
+      return enabled;
+    }
+
+    public static bool isRTAntenna(PartModule module) {
+      return module.part.Modules.Contains("ModuleRTAntenna");
+    }
+  }
+
+} // KERBALISM

--- a/src/Signal.cs
+++ b/src/Signal.cs
@@ -377,6 +377,8 @@ public class Signal : MonoBehaviour
   // - during scene changes the vessel list change asynchronously, but is synched every frame, apparently
   public void Update()
   {
+    if (RemoteTech.isEnabled()) return;
+    
     // get existing antennas
     BuildAntennas();
 
@@ -439,8 +441,19 @@ public class Signal : MonoBehaviour
     // if, for some reasons, there isn't link data for the vessel, return 'no antenna'
     // note: this for example may happen when a resque mission vessel get enabled
     link_data ld;
-    if (!instance.links.TryGetValue(v.id, out ld)) ld.status = link_status.no_antenna;
 
+    if (!instance.links.TryGetValue(v.id, out ld))
+    {
+      if (RemoteTech.isEnabled())
+      {
+        ld.linked = true;
+        ld.status = link_status.direct_link;
+      }
+      else {
+        ld.status = link_status.no_antenna;
+      }
+    }
+      
     // return link status from the cache
     return ld;
   }


### PR DESCRIPTION
Here's a basic attempt to allow Kerbalism work together with RemoteTech.

If user installs both mods, the antenna parts of the Kerbalism will be disabled and all connectivity stuff will be handled by RemoteTech.

It is possible to go further and calculate energy consumption and entertainment using RemoteTech part modules, but I'm not sure whether it worth doing since the resulting code will look kinda ugly. We could always add it later if needed.

Here's the compiled dll for testing: https://dl.dropboxusercontent.com/u/406311534/web/Kerbalism.dll (You will need to paste it to the GameData/Kerbalism and the replace default one)