### PR TITLE
Add basic support for Surface Experiment Package

### DIFF
--- a/GameData/Kerbalism/Patches/contribs/SEP.cfg
+++ b/GameData/Kerbalism/Patches/contribs/SEP.cfg
@@ -1,0 +1,51 @@
+// ============================================================================
+// Surface Experiment Package rebalance for Kerbalism
+// ============================================================================
+
+// The SEP-SPA looks to have roughly the same surface area as OX-STAT,
+// so make it generate the same amount of energy
+@PART[SEP_solarPanel]:FOR[Kerbalism]
+{
+  @MODULE[ModuleDeployableSolarPanel]
+  {
+    @chargeRate = 0.08
+  }
+}
+
+// All experiments should use 1/4th of the energy, in line with existing
+// EC consumer rebalance. Keep the reset cost though.
+@PART[SEP_*]:FOR[Kerbalism]
+{
+  @MODULE[DMModuleScienceAnimateGeneric]
+  {
+	@resourceExpCost *= 0.25
+  }
+}
+
+// Tweak science values for experiments, 100% return rates
+@EXPERIMENT_DEFINITION[*]:HAS[#id[SEP_*]]:FOR[Kerbalism]
+{
+  %baseValue = #$scienceCap$
+}
+
+// Replace Central Station antenna with Commutron 8 equivalent
+@PART[SEP_CentralStation]:FOR[Kerbalism]:NEEDS[!RemoteTech,!AntennaRange,EnableSignal]
+{
+  @MODULE[ModuleDataTransmitter]
+  {
+    @name = Antenna
+    %scope = orbit
+    %relay_cost = 0.03
+    %min_transmission_cost = 1.0
+    %max_transmission_cost = 4.0
+  }
+  
+  // If Antenna module already exists, edit it instead
+  @MODULE[Antenna]
+  {
+    @scope = orbit
+    @relay_cost = 0.03
+    @min_transmission_cost = 1.0
+    @max_transmission_cost = 4.0
+  }
+}


### PR DESCRIPTION
* Rebalance SEP-SPA to provide as much as OX-STAT (looks to have roughly the same surface area).
* Rebalance cost of all experiments to 1/4 of EC, which is in line with other EC consumer rebalance. I've kept the reset cost unchanged, as I haven't touched the station EC capacity. Further rebalance of EC values might be necessary.
* Make all experiments have 100% return rates. Most of the experiments were already doing that already, but this guarantees consistency  for all SEP experiments and is more concise than listing them separately. If Kerbalism design is for ALL science experiments to have 100% return rates then this patch could drop the HAS part and be moved to ScienceTweaks. This is just what https://github.com/maculator/Science-Full-reward does
* Change SEP Central Station antenna to an equivalent of Commutron 8. Editing just the ModuleDataTransmitter doesn't work, maybe it's because this patch is executed after Kerbalism default conversion of all ModuleDataTransmitter to extreme range Antenna in Antenna.cfg