### PR TITLE
Better detection of probes to enable Telemetry

### DIFF
--- a/GameData/Kerbalism/Patches/tweaks/ScienceTweaks.cfg
+++ b/GameData/Kerbalism/Patches/tweaks/ScienceTweaks.cfg
@@ -221,7 +221,7 @@
 // ============================================================================
 
 
-@PART[*]:HAS[@MODULE[ModuleCommand],#CrewCapacity[0]]:FOR[Kerbalism]
+@PART[*]:HAS[@MODULE[ModuleCommand],#vesselType[Probe]]:FOR[Kerbalism]
 {
   MODULE
   {
@@ -243,7 +243,6 @@
     usageReqMaskExternal = -1
   }
 }
-
 
 // ============================================================================
 // Telemetry experiment


### PR DESCRIPTION
With this patch, every part that has `ModuleCommand` and `vesselType=Probe` will be counted as a Probe for purposes of enabling the Telemetry experiment. I feel this is a superior method to counting on `CrewCapacity=0` being present as it is both unnecessary to specify 0 capacity and this setting is actually lacking on HECS-2 and RoveMate, leaving those probe cores without Telemetry.

The downside is that it probably won't work with parts that are normal crewed pods, but can also operate autonomously, e.g. Nertea's awesome 2 kerbal pod from NFT Spaceships. I feel it would make more sense to add Telemetry explicitly to such pods via a contrib MM patch, than to rely on something that doesn't work properly for stock parts.