### PR TITLE
Adding radiation emitters for the Atomic Age mod

### DIFF
--- a/GameData/Kerbalism/Patches/contribs/AtomicAge.cfg
+++ b/GameData/Kerbalism/Patches/contribs/AtomicAge.cfg
@@ -1,0 +1,34 @@
+// ============================================================================
+// Radiation emitters for Atomic Age nuclear engines
+// by ThePsion5
+// ============================================================================
+
+@PART[NuclearJetEngine]:AFTER[AtomicAge]:NEEDS[AtomicAge]
+{
+  MODULE
+  {
+    name = Emitter
+    radiation = 0.0000041666 // 0.015 rad/h
+    tooltip = This engine emits ionizing radiation.
+  }
+}
+
+@PART[nuclearEngineKANDL]:AFTER[AtomicAge]:NEEDS[AtomicAge]
+{
+  MODULE
+  {
+    name = Emitter
+    radiation = 0.0000022222 // 0.008 rad/h
+    tooltip = This engine emits ionizing radiation.
+  }
+}
+
+@PART[nuclearEngineLightbulb]:AFTER[AtomicAge]:NEEDS[AtomicAge]
+{
+  MODULE
+  {
+    name = Emitter
+    radiation = 0.0000083331 // 0.03 rad/h
+    tooltip = This engine emits ionizing radiation.
+  }
+}


### PR DESCRIPTION
Adds ionizing radiation for Atomic Age's nuclear engines. Emissions are balanced accordingly:

| Engine Name | rads/hour | % of LV-N rads |
| --- | --- | --- |
| Nuclear Turbojet | 0.015 | 150% |
| "KANDL" | 0.008 |  80% |
| Nuclear Lightbulb | 0.030 | 300% |

Tested with: Kerbal Space Program v1.1.3, Kerbalism v1.1.3, Atomic Age v3.1
