### PR TITLE
Improve support for Ven's Stock Revamp

### DIFF
--- a/GameData/Kerbalism/Patches/contribs/VenStockRevamp.cfg
+++ b/GameData/Kerbalism/Patches/contribs/VenStockRevamp.cfg
@@ -250,4 +250,14 @@
     radiation = 0.00000055555 // 0.002 rad/h
     tooltip = This engine emits ionizing radiation.
   }
+  
+  @MODULE[ModuleGenerator] 
+  {
+    @OUTPUT_RESOURCE[ElectricCharge]
+    {
+      @rate *= 0.25
+    }
+  }
+  
+  // ModuleAlternator is handled by the generic energy tweak
 }

--- a/GameData/Kerbalism/Patches/contribs/VenStockRevamp.cfg
+++ b/GameData/Kerbalism/Patches/contribs/VenStockRevamp.cfg
@@ -72,7 +72,7 @@
 
 @PART[InflatableHAB]:NEEDS[VenStockRevamp]:FOR[Kerbalism]
 {
-  @CrewCapacity = 0
+  @CrewCapacity,* = 0
   !vesselType = delete
   !MODULE[ModuleScienceExperiment] {}
   !MODULE[ModuleScienceContainer] {}
@@ -101,6 +101,19 @@
   }
 }
 
+// ============================================================================
+// Balance PPD-20 Jumbo Kerbal Can to match Hitchhiker Storage and IKU-03
+// ============================================================================
+
+@PART[LargeInflatableHAB]:NEEDS[VenStockRevamp]:FOR[Kerbalism]
+{
+  MODULE
+  {
+    name = Entertainment
+    description = Kerbals feel much happier knowing they can spend their free time in this spacious and pleasantly furnished module.
+    rate = 2.0
+  }
+}
 
 // ============================================================================
 // Support ven's antennas
@@ -213,4 +226,28 @@
 @PART[HeatShield3]:NEEDS[VenStockRevamp]:FOR[Kerbalism_VSR]
 {
   @crashTolerance = 14
+}
+
+// ============================================================================
+// Add radiation to additional nuclear engines found in VSR
+// ============================================================================
+
+@PART[size2nuclearEngine]
+{
+  MODULE
+  {
+    name = Emitter
+    radiation = 0.0000083333 // 0.03 rad/h
+    tooltip = This engine emits ionizing radiation.
+  }
+}
+
+@PART[PoodleM]
+{
+  MODULE
+  {
+    name = Emitter
+    radiation = 0.00000055555 // 0.002 rad/h
+    tooltip = This engine emits ionizing radiation.
+  }
 }


### PR DESCRIPTION
* Add radiation emitter to nuclear engines added by VSR. Radiation amount balanced around max thrust vs. stock nuclear engine. Not sure if those numbers actually make any kind of sense.
* Add entertainment to  PPD-20 Jumbo Kerbal Can. It's basically 10 person hitchhiker, so add the same amount of entertainment as on 10 Kerbal inflatable hab IKU-03. Flavour text could use some improvement.
* Provide workaround for VSR 1.9.5 having multiple instances of CrewCapacity on IKU-03. Ven already accepted pull request with fix, but I have no idea when he'll release. This patch will still work correctly after fixed VSR is released.