### PR TITLE
Add support for JX2Antenna

### DIFF
--- a/GameData/Kerbalism/Support/JX2Antenna.cfg
+++ b/GameData/Kerbalism/Support/JX2Antenna.cfg
@@ -1,0 +1,40 @@
+// Support for JX2 Antenna from https://github.com/KSPSnark/JX2Antenna
+
+// A long-range, very reliable antenna that can provide DSN link even
+// when using Outer Planets Mod
+
+@PART[jx2LDA]:NEEDS[FeatureSignal]:FOR[Kerbalism]:AFTER[JX2Antenna]
+{
+  !MODULE[ModuleDataTransmitter] {}
+  !MODULE[ModuleDeployableAntenna] {}
+  
+  MODULE
+  {
+    name = Antenna
+    type = high_gain
+    cost = 1.98
+    dist = 1.0e12
+    rate = 0.256
+  }
+
+  MODULE:NEEDS[FeatureReliability]
+  {
+    name = Reliability
+    type = Antenna
+    title = Antenna
+    redundancy = Communication
+    repair = Engineer
+    mtbf = 108864000  // 12y
+    extra_cost = 3.0
+    extra_mass = 0.5
+  }
+  
+  MODULE
+  {
+    name = ModuleAnimationGroup
+    deployAnimationName = deployHexes
+    moduleType = Antenna
+  }
+  
+  @description = An enormous High-Gain antenna, powerful enough to maintain contact with DSN even from the farthest outskirts of the system. It has been built from the highest quality components available, thus ensuring a long and reliable service.
+}


### PR DESCRIPTION
* Add Kerbalism support for JX2Antenna from https://github.com/KSPSnark/JX2Antenna
* Configure JX2Antenna as a 1Tm High-Gain with very high power consumption, mass, and cost
* JX2Antenna is configured with 12y base reliability (as opposed to 8 in other antennas). This is justified by this antenna being specifically designed to be used for long term deep space missions.
* Example usage mission in Outer Planet Mods - main antenna on a satellite carrier to Plock-Karen System. Shortest time to destination is ~23 years, max distance from Kerbin ~688Gm