### PR TITLE
Improve support for  Stock-Alike Station Parts

### DIFF
--- a/GameData/Kerbalism/Support/SSPX.cfg
+++ b/GameData/Kerbalism/Support/SSPX.cfg
@@ -12,3 +12,30 @@
   @tags ^= :$: comfort:
 }
 
+@PART[crewpod-observation-25]:NEEDS[FeatureSignal]:FOR[Kerbalism]
+{
+  !MODULE[ModuleDataTransmitter] {}
+
+  MODULE
+  {
+    name = Antenna
+    type = low_gain
+    cost = 0.1
+    dist = 5e6
+    rate = 0.016
+  }
+
+  MODULE:NEEDS[FeatureReliability]
+  {
+    name = Reliability
+    type = Antenna
+    title = Antenna
+    redundancy = Communication
+    repair = true
+    mtbf = 72576000 // 8y
+    extra_cost = 2.0
+    extra_mass = 1.0
+  }
+
+  @description ^= :$: A built-in low-gain antenna allows the occupants to transmit their screams while viewing the oncoming space debris.
+}


### PR DESCRIPTION
* make PPD-24 built-in antenna Kerbalism compatible. The stats are taken from the small fixed antenna.
* modify PPD-24 description to mention presence of antenna explicitly

Happy New Year!