### PR TITLE
Make NFT Argon and Xenon extractor use Harvester module

### DIFF
--- a/GameData/Kerbalism/Support/NearFuture.cfg
+++ b/GameData/Kerbalism/Support/NearFuture.cfg
@@ -1,5 +1,5 @@
 // ============================================================================
-// Tweak stuff from NearFutureSpacecraft
+// Tweak stuff from NearFuture suite
 // ============================================================================
 
 // The Mk3-9 pod was intended to have advanced technology that allows it to continue
@@ -24,5 +24,83 @@
       name = ElectricCharge
       rate = 0.03
     }
+  }
+}
+
+// ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+// Profile-specific changes
+// ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+@PART[cryoseperator-25]:AFTER[NearFuturePropulsion]:NEEDS[ProfileDefault]
+{
+  !MODULE[ModuleResourceHarvester],* {}
+  !MODULE[Reliability],* {}
+
+  MODULE
+  {
+    name = Harvester
+    title = Xenon Fractional Distiler
+    type = 2
+    resource = XenonGas
+    min_abundance = 0.0
+    min_pressure = 1.0
+    rate = 0.2
+    ec_rate = 13.75
+  }
+
+  MODULE
+  {
+    name = Harvester
+    title = Argon Fractional Distiler
+    type = 2
+    resource = ArgonGas
+    min_abundance = 0.0
+    min_pressure = 1.0
+    rate = 0.95
+    ec_rate = 23.75
+  }
+
+  MODULE
+  {
+    name = Configure
+    title = Cryogenic Atmospheric Separator
+    slots = 1
+
+    SETUP
+    {
+      name = Xenon Fractional Distiler
+      desc = Distil <b>Xenon</b> from the atmosphere.
+
+      MODULE
+      {
+        type = Harvester
+        id_field = resource
+        id_value = XenonGas
+      }
+    }
+
+    SETUP
+    {
+      name = Argon Fractional Distiler
+      desc = Distil <b>Argon</b> from the atmosphere.
+
+      MODULE
+      {
+        type = Harvester
+        id_field = resource
+        id_value = ArgonGas
+      }
+    }
+  }
+
+  MODULE:NEEDS[FeatureReliability]
+  {
+    name = Reliability
+    type = Harvester
+    title = Harvester
+    repair = Engineer
+    mtbf = 72576000 // 8y
+    extra_cost = 1.0
+    extra_mass = 0.5
   }
 }

--- a/GameData/Kerbalism/Support/NearFuture.cfg
+++ b/GameData/Kerbalism/Support/NearFuture.cfg
@@ -42,7 +42,7 @@
     title = Xenon Fractional Distiler
     type = 2
     resource = XenonGas
-    min_abundance = 0.0
+    min_abundance = 0.0000001
     min_pressure = 1.0
     rate = 0.2
     ec_rate = 13.75
@@ -54,7 +54,7 @@
     title = Argon Fractional Distiler
     type = 2
     resource = ArgonGas
-    min_abundance = 0.0
+    min_abundance = 0.005
     min_pressure = 1.0
     rate = 0.95
     ec_rate = 23.75

--- a/GameData/Kerbalism/System/Resources.cfg
+++ b/GameData/Kerbalism/System/Resources.cfg
@@ -149,6 +149,20 @@ RESOURCE_DEFINITION
   isVisible = true
 }
 
+RESOURCE_DEFINITION
+{
+	name = ArgonGas // Common electric engine propellant
+	density = 0.00000178400
+	unitCost = 0.0105
+	flowMode = STAGE_PRIORITY_FLOW
+	transfer = PUMP
+	isTweakable = true
+    isVisible = true
+	color = 1,0,0
+	volume = 1
+    ksparpicon = TriggerTech/KSPAlternateResourcePanel/Icons/Argon
+}
+
 
 // ============================================================================
 // Planetary resources
@@ -237,6 +251,35 @@ PLANETARY_RESOURCE
   }
 }
 
+PLANETARY_RESOURCE
+{
+	ResourceName = ArgonGas
+	ResourceType = 2
+	PlanetName = Kerbin
+	
+	Distribution
+	{
+		PresenceChance = 100
+		MinAbundance = 0.01
+		MaxAbundance = 0.1
+		Variance = 5
+	}
+}
+
+PLANETARY_RESOURCE
+{
+	ResourceName = XenonGas
+	ResourceType = 2
+	PlanetName = Kerbin
+	
+	Distribution
+	{
+		PresenceChance = 100
+		MinAbundance = 0.00000009
+		MaxAbundance = 0.0000002
+		Variance = 5
+	}
+}
 
 // Mun ------------------------------------------------------------------------
 
@@ -307,6 +350,21 @@ PLANETARY_RESOURCE
   }
 }
 
+PLANETARY_RESOURCE
+{
+	ResourceName = ArgonGas
+	ResourceType = 2
+	PlanetName = Duna
+	
+	Distribution
+	{
+		PresenceChance = 100
+		MinAbundance = 0.001
+		MaxAbundance = 0.01
+		Variance = 5
+	}
+}
+
 
 // Eve ------------------------------------------------------------------------
 
@@ -356,6 +414,21 @@ PLANETARY_RESOURCE
     MaxAbundance = 90
     Variance = 0
   }
+}
+
+PLANETARY_RESOURCE
+{
+	ResourceName = ArgonGas
+	ResourceType = 2
+	PlanetName = Jool
+	
+	Distribution
+	{
+		PresenceChance = 100
+		MinAbundance = 0.07
+		MaxAbundance = 1
+		Variance = 5
+	}
 }
 
 


### PR DESCRIPTION
* Switch M-2 Cryogenic Gas Separator to use Harvester Module. 
  * EC consumption and production rates lifted from NFT config itself.
  * NFT doesn't require any abundance requirement to get those gasses. Probably makes sense, as the process is supposed to first compress the atmospheric gas, then cryogenically distil Argon and Xenon from it. Might need a balance pass in the future.
  * Required minimum pressure is also debatable, no such requirement on original mod. All the pumps I know of thought have a minimum "outside" pressure though. Balance pass might be in order.
  * Original part can do both xenon and argon in one go, I made this with only one slot. I feel that the extraction process should require quite a lot of machinery, so having both in a single part seems an overkill.