### PR TITLE
Update OrbitalScience.cfg

### DIFF
--- a/GameData/Kerbalism/Support/OrbitalScience.cfg
+++ b/GameData/Kerbalism/Support/OrbitalScience.cfg
@@ -17,3 +17,139 @@
 @EXPERIMENT_DEFINITION[*]:HAS[#id[dmbathymetryscan]]:NEEDS[DMagicOrbitalScience,FeatureScience]:FOR[Kerbalism]  { @dataScale = 18  }
 @EXPERIMENT_DEFINITION[*]:HAS[#id[dmbiodrillscan]]:NEEDS[DMagicOrbitalScience,FeatureScience]:FOR[Kerbalism]    { @dataScale = 88  }
 @EXPERIMENT_DEFINITION[*]:HAS[#id[AnomalyScan]]:NEEDS[DMagicOrbitalScience,FeatureScience]:FOR[Kerbalism]       { @dataScale = 42  }
+
+// tweaking of DMagicOrbitalScience "Oversize Signals Intelligence Satellite"
+
+@PART[dmSIGINT]:NEEDS[FeatureSignal]:FOR[Kerbalism]:AFTER[DMagicOrbitalScience]
+
+{
+  !MODULE[ModuleDataTransmitter] {}
+
+// remove stock transmission code
+
+  MODULE
+  {
+    name = Antenna
+    type = high_gain
+    cost = 1.98
+    dist = 7.0e10
+    rate = 0.032
+  }
+
+  MODULE:NEEDS[FeatureReliability]
+  {
+    name = Reliability
+    type = Antenna
+    title = Antenna
+    redundancy = Communication
+    repair = Engineer
+    mtbf = 72576000  // 8y
+    extra_cost = 3.0
+    extra_mass = 0.65
+  }
+
+  MODULE
+  {
+    name = ModuleAnimationGroup
+    deployAnimationName = dishDeploy
+    moduleType = Antenna
+  }
+
+// Play animation
+
+  @description = A grossly oversized radio signals intelligence dish that can be used for listening in to every imaginable from of communication, discovering radio anomalies on a planet's surface, or just impressing your neighbor. Warning: Dish is FRAGILE; it is NOT for use in the atmosphere; CANNOT be retracted! Can be used at up to five times the normal low orbit altitude. This instrument can also be used as a powerful communications antenna however it lacks high data throughput and uses a lot of electricity!
+
+}
+
+// tweaking of DMagicOrbitalScience "Oversize Signals Intelligence Satellite_End"
+
+@PART[dmSIGINT.End]:NEEDS[FeatureSignal]:FOR[Kerbalism]:AFTER[DMagicOrbitalScience]
+
+{
+  !MODULE[ModuleDataTransmitter] {}
+
+// remove stock transmission code
+
+  MODULE
+  {
+    name = Antenna
+    type = high_gain
+    cost = 1.98
+    dist = 7.0e10
+    rate = 0.032
+  }
+
+  MODULE:NEEDS[FeatureReliability]
+  {
+    name = Reliability
+    type = Antenna
+    title = Antenna
+    redundancy = Communication
+    repair = Engineer
+    mtbf = 72576000  // 8y
+    extra_cost = 3.0
+    extra_mass = 0.65
+  }
+
+  MODULE
+  {
+    name = ModuleAnimationGroup
+    deployAnimationName = dishDeploy
+    moduleType = Antenna
+  }
+
+  @description = A grossly oversized radio signals intelligence dish that can be used for listening in to every imaginable from of communication, discovering radio anomalies on a planet's surface, or just impressing your neighbor. Warning: Dish is FRAGILE; it is NOT for use in the atmosphere; CANNOT be retracted! Can be used at up to five times the normal low orbit altitude. This instrument can also be used as a powerful communications antenna however it lacks high data throughput and uses a lot of electricity!
+
+}
+
+// tweaking of DMagicOrbitalScience "Oversize Signals Intelligence Satellite_Small"
+
+@PART[dmSIGINT.Small]:NEEDS[FeatureSignal]:FOR[Kerbalism]:AFTER[DMagicOrbitalScience]
+
+{
+  !MODULE[ModuleDataTransmitter] {}
+
+// remove stock transmission code
+
+  MODULE
+  {
+    name = Antenna
+    type = high_gain
+    cost = 1.48
+    dist = 5.0e10
+    rate = 0.032
+  }
+
+  MODULE:NEEDS[FeatureReliability]
+  {
+    name = Reliability
+    type = Antenna
+    title = Antenna
+    redundancy = Communication
+    repair = Engineer
+    mtbf = 72576000  // 8y
+    extra_cost = 3.0
+    extra_mass = 0.65
+  }
+
+  MODULE
+  {
+    name = ModuleAnimationGroup
+    deployAnimationName = dishDeploy
+    moduleType = Antenna
+  }
+
+  @description = A mildly oversized radio signals intelligence dish that can be used for listening in to every imaginable from of communication, discovering radio anomalies on a planet's surface, or just impressing your neighbor. Warning: Dish is FRAGILE; it is NOT for use in the atmosphere; CANNOT be retracted! Can be used at up to five times the normal low orbit altitude. This instrument can also be used as a powerful communications antenna however it lacks data throughput and is inefficient.
+
+}
+
+@PART[dmSoilMoisture]:NEEDS[FeatureSignal]:FOR[Kerbalism]:AFTER[DMagicOrbitalScience]
+
+{
+  !MODULE[ModuleDataTransmitter] {}
+
+// remove stock transmission code
+
+  @description =This orbital sensor deploys a large L-band microwave detector comprised of 82 individual antenna elements. It can be used to study the water content of the upper soil layers and the salinity levels of large water features. Can only be used in low orbit. Due to the large size of the surface moisture sensory array, this device cannot serve as an antennae.
+
+}


### PR DESCRIPTION
This changes the DMagic antennae from the ridiculous 10 T to 280 Gm, and I changed the data Tx rate to 0.032 to bring it more in line with other antenna you'll have around this tech level. These give the player a real choice if they want to go really far away but only have limited Data throughput; they can now make that choice. They don't work in Atmosphere and can't relay since they are high-gain so they should be pretty balanced and provide a meaningful experience for people who want to send early probes to very distant bodies with the understanding they won't be able to transmit a lot of data quickly.

Removes the Soil Moisture Sensor as an Antennae.

Feel free to tweak to your liking for balance purposes. This is my first MM Patch! 👍 

Shoutout to Yaar Podshipnik for helping my figure this out.
http://forum.kerbalspaceprogram.com/index.php?/topic/137227-122-kerbalism-v118/&page=140#comment-2920529