### PR TITLE
Add support for RLA Stockalike Continued

### DIFF
--- a/GameData/Kerbalism/Support/RLAStockalikeContinued.cfg
+++ b/GameData/Kerbalism/Support/RLAStockalikeContinued.cfg
@@ -1,0 +1,36 @@
+// Patches for RLA Stockalike Continued
+
+@PART[RLA_mp_small_fuelcell]:NEEDS[RLA_Stockalike]:FOR[Kerbalism]
+{
+  !MODULE[ModuleResourceConverter] {}
+  !RESOURCE[ElectricCharge] {}
+
+  MODULE
+  {
+    name = ProcessController
+    resource = _MonopropFuelCell
+    title = Monoprop Fuel Cell
+    capacity = 2
+  }
+
+  MODULE:NEEDS[FeatureReliability]
+  {
+    name = Reliability
+    type = ProcessController
+    title = Monoprop Fuel Cell
+    redundancy = Power Generation
+    repair = Engineer
+    mtbf = 72576000 // 8y
+    extra_cost = 1.0
+    extra_mass = 0.5
+  }
+}
+
+@PART[RLA_mmrtg]:NEEDS[RLA_Stockalike,FeatureRadiation]:FOR[Kerbalism]
+{
+  MODULE
+  {
+    name = Emitter
+    radiation = 0.00000009258 // 0.00003 rad/h, shows as nominal
+  }
+}


### PR DESCRIPTION
* convert the RLA monoprop fuel cell to Kerbalism one. As it is a dedicated part it has twice the efficiency of the base cell installed in pods. Reliability same as standard fuel cell. Ability to store EC removed to keep it inline with standard fuel cell.
* make the small RLA RTG emit some radiation. It generates 1/6th of the EC of stock RTG so it emits 1/6th of radiation. The amount is so small it shows as "nominal" in game.