### PR TITLE
Add a "crew_count" modifier

### DIFF
--- a/src/Profile/Modifiers.cs
+++ b/src/Profile/Modifiers.cs
@@ -60,7 +60,7 @@ public static class Modifiers
           break;
           
         case "crew_count":
-          k *= (double)va.crew_count;
+          k *= (double)vi.crew_count;
           break;
 
         default:

--- a/src/Profile/Modifiers.cs
+++ b/src/Profile/Modifiers.cs
@@ -58,6 +58,10 @@ public static class Modifiers
         case "per_capita":
           k /= (double)Math.Max(vi.crew_count, 1);
           break;
+          
+        case "crew_count":
+          k *= (double)va.crew_count;
+          break;
 
         default:
           k *= resources.Info(v, mod).amount;
@@ -117,6 +121,10 @@ public static class Modifiers
 
         case "per_capita":
           k /= (double)Math.Max(va.crew_count, 1);
+          break;
+          
+        case "crew_count":
+          k *= (double)va.crew_count;
           break;
 
         default:


### PR DESCRIPTION
Currently, the only way to have a "per kerbal" resource output is an ugly workaround that involve to put some "DummyResource" capacity in some part and then :

Process
{
	output = DummyResource@SomeHighRate
}

Rule
{
	input = DummyResource
	output = PerKerbalResource
	rate, ratio, degeneration, etc
}

This simple "crew_count" modifier allow to achieve this in a saner way, and allow to define if the output should be dumped :
Process
{
	modifier = crew_count
	output = PerKerbalResource@SomeRate
	dump = false
}