### PR TITLE
Fix typo for manageResqueMission method and effected comments.

### DIFF
--- a/src/Cache.cs
+++ b/src/Cache.cs
@@ -111,7 +111,7 @@ public sealed class vessel_info
   public UInt64       inc;                  // unique incremental id for the entry
   public bool         is_vessel;            // true if this is a valid vessel
   public bool         is_rescue;            // true if this is a rescue mission vessel
-  public bool         is_valid;             // equivalent to (is_vessel && !is_resque && !eva_dead)
+  public bool         is_valid;             // equivalent to (is_vessel && !is_rescue && !eva_dead)
   public UInt32       id;                   // generate the id once
   public int          crew_count;           // number of crew on the vessel
   public int          crew_capacity;        // crew capacity of the vessel

--- a/src/Profile/Rule.cs
+++ b/src/Profile/Rule.cs
@@ -67,7 +67,7 @@ public sealed class Rule
       // get kerbal data
       KerbalData kd = DB.Kerbal(c.name);
 
-      // skip resque kerbals
+      // skip rescue kerbals
       if (kd.rescue) continue;
 
       // skip disabled kerbals

--- a/src/Profile/Supply.cs
+++ b/src/Profile/Supply.cs
@@ -112,7 +112,7 @@ public sealed class Supply
 
   public void SetupRescue(Vessel v)
   {
-    // do nothing if no resource on resque
+    // do nothing if no resource on rescue
     if (on_rescue <= double.Epsilon) return;
 
     // if the vessel has no capacity

--- a/src/System/Kerbalism.cs
+++ b/src/System/Kerbalism.cs
@@ -114,11 +114,11 @@ public sealed class Kerbalism : ScenarioModule
         EVA.update(v);
       }
 
-      // keep track of resque mission kerbals, and gift resources to their vessels on discovery
+      // keep track of rescue mission kerbals, and gift resources to their vessels on discovery
       if (v.loaded && vi.is_vessel)
       {
-        // manage resque mission mechanics
-        Misc.manageResqueMission(v);
+        // manage rescue mission mechanics
+        Misc.manageRescueMission(v);
       }
 
       // do nothing else for invalid vessels
@@ -336,27 +336,27 @@ public static class Misc
   }
 
 
-  public static void manageResqueMission(Vessel v)
+  public static void manageRescueMission(Vessel v)
   {
-    // true if we detected this was a resque mission vessel
+    // true if we detected this was a rescue mission vessel
     bool detected = false;
 
-    // deal with resque missions
+    // deal with rescue missions
     foreach(ProtoCrewMember c in Lib.CrewList(v))
     {
       // get kerbal data
       KerbalData kd = DB.Kerbal(c.name);
 
-      // flag the kerbal as not resque at prelaunch
+      // flag the kerbal as not rescue at prelaunch
       if (v.situation == Vessel.Situations.PRELAUNCH) kd.rescue = false;
 
-      // if the kerbal belong to a resque mission
+      // if the kerbal belong to a rescue mission
       if (kd.rescue)
       {
         // remember it
         detected = true;
 
-        // flag the kerbal as non-resque
+        // flag the kerbal as non-rescue
         // note: enable life support mechanics for the kerbal
         kd.rescue = false;
 
@@ -470,10 +470,10 @@ public static class Misc
   }
 
 
-  // return true if the vessel is a resque mission
+  // return true if the vessel is a rescue mission
   public static bool IsRescueMission(Vessel v)
   {
-    // if at least one of the crew is flagged as resque, consider it a resque mission
+    // if at least one of the crew is flagged as rescue, consider it a rescue mission
     foreach(var c in Lib.CrewList(v))
     {
       if (DB.Kerbal(c.name).rescue) return true;


### PR DESCRIPTION
Fixed a typo where Rescue was misspelled Resque on the manageResqueMission method name in Kerbalism.cs by renaming it to manageRescueMission and also its call.
Changed all other misspelled Resque found.