### PR TITLE
UI persistence, load and save UI data to .sfs file.

### DIFF
--- a/src/Database/DB.cs
+++ b/src/Database/DB.cs
@@ -62,6 +62,16 @@ public static class DB
       landmarks = new LandmarkData();
     }
 
+    // load UI data
+    if (node.HasNode("UIdata"))
+    {
+      UIdata = new UIData(node.GetNode("UIdata"));
+    }
+    else
+    {
+      UIdata = new UIData();
+    }
+
     // if an old savegame was imported, log some debug info
     if (version != Lib.Version()) Lib.Log("savegame converted from version " + version);
   }
@@ -98,6 +108,9 @@ public static class DB
 
     // save landmark data
     landmarks.save(node.AddNode("landmarks"));
+
+    // save UI data
+    UIdata.save(node.AddNode("UIdata"));
   }
 
 
@@ -141,6 +154,7 @@ public static class DB
   public static Dictionary<uint, VesselData> vessels;    // store data per-vessel, indexed by root part id
   public static Dictionary<string, BodyData> bodies;     // store data per-body
   public static LandmarkData landmarks;                  // store landmark data
+  public static UIData UIdata;                           // store UI data
 }
 
 

--- a/src/Database/UIData.cs
+++ b/src/Database/UIData.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+
+namespace KERBALISM {
+
+
+  public class UIData
+  {
+    public UIData()
+    {
+      popout_window_left = 280;
+      popout_window_top = 100;
+      mapviewed = false;
+    }
+
+    public UIData(ConfigNode node)
+    {
+      popout_window_left = Lib.ConfigValue(node, "popout_window_left", 280);
+      popout_window_top = Lib.ConfigValue(node, "popout_window_top", 100);
+      mapviewed = Lib.ConfigValue(node, "mapviewed", false);
+    }
+
+    public void save(ConfigNode node)
+    {
+      node.AddValue("popout_window_left", popout_window_left);
+      node.AddValue("popout_window_top", popout_window_top);
+      node.AddValue("mapviewed", mapviewed);
+    }
+
+    public float popout_window_left;       // popout window position left
+    public float popout_window_top;        // popout window position top
+    public bool  mapviewed;                // has the user entered map-view/tracking-station
+  }
+
+
+} // KERBALISM

--- a/src/System/Kerbalism.cs
+++ b/src/System/Kerbalism.cs
@@ -59,6 +59,9 @@ public sealed class Kerbalism : ScenarioModule
       savegame_uid = DB.uid;
     }
 
+    // load UI data
+    UI.load();
+
     // force CommNet off when signal is enabled
     HighLogic.fetch.currentGame.Parameters.Difficulty.EnableCommNet &= !Features.Signal;
   }

--- a/src/UI/UI.cs
+++ b/src/UI/UI.cs
@@ -16,6 +16,12 @@ public static class UI
     window   = new Window(260u, 280u, 100u);
   }
 
+  public static void load()
+  {
+    window.load();
+    first_time_mapview = DB.UIdata.mapviewed;
+  }
+
   public static void update(bool show_window)
   {
     // if gui should be shown
@@ -27,6 +33,7 @@ public static class UI
       {
         open(BodyInfo.body_info);
         first_time_mapview = true;
+        DB.UIdata.mapviewed = first_time_mapview;
       }
 
       // update subsystems

--- a/src/UI/Window.cs
+++ b/src/UI/Window.cs
@@ -28,6 +28,11 @@ public sealed class Window
     tooltip = new Tooltip();
   }
 
+  public void load()
+  {
+      win_rect.Set(DB.UIdata.popout_window_left, DB.UIdata.popout_window_top, win_rect.width, win_rect.height);
+  }
+
   public void open(Action<Panel> refresh)
   {
     this.refresh = refresh;
@@ -75,6 +80,10 @@ public sealed class Window
     win_rect.xMax += offset_x;
     win_rect.yMin += offset_y;
     win_rect.yMax += offset_y;
+
+    // store the window position to DB
+    DB.UIdata.popout_window_left = win_rect.xMin;
+    DB.UIdata.popout_window_top = win_rect.yMin;
 
     // draw the window
     win_rect = GUILayout.Window(win_id, win_rect, draw_window, "", Styles.win);


### PR DESCRIPTION
Added a UIData class to enable loading and saving of UI information to the .sfs file, such as positions, sizes, styles etc. Works via the DB class and uses public member access, just as the other Database classes do.
#### Currently supports the saving and loading of:
  - The popout window's position.
  - Map/TrackingStation viewed state (Comes in handy to stop the body info popout window opening every time a game is started).