### PR TITLE
Support for SSTU

### DIFF
--- a/GameData/Kerbalism/Support/SSTU.cfg
+++ b/GameData/Kerbalism/Support/SSTU.cfg
@@ -23,7 +23,7 @@
     extra_cost = 1.0
     extra_mass = 0.5
   }
-
+}
 
   @PART[SSTU-SC-GEN-HGA]:NEEDS[SSTU]:FOR[Kerbalism]
   {

--- a/GameData/Kerbalism/Support/SSTU.cfg
+++ b/GameData/Kerbalism/Support/SSTU.cfg
@@ -1,0 +1,53 @@
+// Patches for SSTU Lab, WIP
+
+@PART[SSTU-SC-E-FS]:NEEDS[SSTU]:FOR[Kerbalism]
+{
+  !MODULE[ModuleResourceConverter] {}
+
+  MODULE
+  {
+    name = ProcessController
+    resource = _FuelCell
+    title = Fuel cell
+    capacity = 3
+  }
+
+  MODULE:NEEDS[FeatureReliability]
+  {
+    name = Reliability
+    type = ProcessController
+    title = Fuel Cell
+    redundancy = Power Generation
+    repair = Engineer
+    mtbf = 72576000 // 8y
+    extra_cost = 1.0
+    extra_mass = 0.5
+  }
+
+
+  @PART[SSTU-SC-GEN-HGA]:NEEDS[SSTU]:FOR[Kerbalism]
+  {
+    MODULE
+    {
+      name = Antenna
+      type = low_gain
+      cost = 0.1
+      dist = 5e6
+      rate = 0.016
+    }
+
+    MODULE:NEEDS[FeatureReliability]
+    {
+      name = Reliability
+      type = Antenna
+      title = Antenna
+      redundancy = Communication
+      repair = true
+      mtbf = 72576000 // 8y
+      extra_cost = 2.0
+      extra_mass = 1.0
+    }
+
+    !MODULE[ModuleDataTransmitter] {}
+
+  }

--- a/GameData/Kerbalism/Support/SSTU.cfg
+++ b/GameData/Kerbalism/Support/SSTU.cfg
@@ -1,6 +1,6 @@
 // Patches for SSTU Lab, WIP
 
-@PART[SSTU-SC-E-FS]:NEEDS[SSTU]:FOR[Kerbalism]
+@PART[SSTU-SC-E-FS]:NEEDS[ProfileDefault|ProfileClassic&SSTU]:FOR[Kerbalism]
 {
   !MODULE[ModuleResourceConverter] {}
 


### PR DESCRIPTION
Sorry that I've made a issue tracker with the exact same topic. I'm meaning to use pull request. The patch needs a lot of work though.

I've started making a patch for SSTU. I'd like to hear your suggestion as this is a fairly big mod and my modding experience is very limited.

Currently, the patch only includes the fuel cells which is included in the Class-E Shuttle and the HG antenna. For the fuel cell, I've noticed that the whole life support system on the shuttle requires around 8.5 EC/s to run. Since the actual shuttle gets all its electricity from the fuel cell I've decided to give it a capacity of 20 (10 EC/s). This has been tested and works fairly well. For the HGA however, I've failed to make it work. Would love it if you can take a look.

Also, although the SSTU uses its own moduelSSTUSolarPanel, its interaction with electric charge is detected by Kerbalism already so not much has to be done there.

I've also noticed that in SSTU the class-E docking port also has a crew capacity of one, Kerbalism thus has given it its own scrubber and pressure control. Can I assume that you're happy with this staying unchanged?