### PR TITLE
ADD: Support for Coatl Aerospace

### DIFF
--- a/GameData/Kerbalism/Support/Coatl.cfg
+++ b/GameData/Kerbalism/Support/Coatl.cfg
@@ -1,0 +1,415 @@
+// ============================================================================
+// Standalone Antennas
+// by dieDoktor
+// ============================================================================
+
+@PART[antenna_cone_toggle]:NEEDS[FeatureSignal]:FOR[Kerbalism]
+{
+  MODULE
+  {
+    name = Antenna
+    type = low_gain
+    cost = 0.1
+    dist = 5e6
+    rate = 0.016
+    // Distance decided based on default figures given in Kerbalism
+  }
+  MODULE:NEEDS[FeatureReliability]
+  {
+    name = Reliability
+    type = Antenna
+    title = Antenna
+    redundancy = Communication
+    repair = true
+    mtbf = 72576000 // 8y
+    extra_cost = 2.0
+    extra_mass = 1.0
+  } // VV importante to use close boyyes. makes code work vv good
+}
+
+@PART[antenna_GPS]:NEEDS[FeatureSignal]:FOR[Kerbalism]
+{
+  MODULE
+  {
+    name = Antenna
+    type = low_gain
+    cost = 0.1
+    dist = 2e6
+    rate = 0.016
+    // Distance decided based on flavor text citing the antenna as not being particularly powerful
+  }
+  MODULE:NEEDS[FeatureReliability]
+  {
+    name = Reliability
+    type = Antenna
+    title = Antenna
+    redundancy = Communication
+    repair = true
+    mtbf = 72576000 // 8y
+    extra_cost = 2.0
+    extra_mass = 1.0
+  }
+}
+
+@PART[antenna_quetzal]:NEEDS[FeatureSignal]:FOR[Kerbalism]
+{
+  MODULE
+  {
+    name = Antenna
+    type = low_gain
+    cost = 0.1
+    dist = 3e6 
+    rate = 0.013
+    // Distance decided based on flavor text citing the antenna as a broken Communitron 16. So it's slightly inferior
+  }
+  MODULE:NEEDS[FeatureReliability]
+  {
+    name = Reliability
+    type = Antenna
+    title = Antenna
+    redundancy = Communication
+    repair = true
+    mtbf = 72576000 // 8y
+    extra_cost = 2.0
+    extra_mass = 1.0
+  }
+}
+
+@PART[antenna_tv]:NEEDS[FeatureSignal]:FOR[Kerbalism]
+{
+  MODULE
+  {
+    name = Antenna
+    type = low_gain
+    cost = 0.1
+    dist = 5e6
+    rate = 0.016
+    // Distance decided based on default figures given in Kerbalism
+  }
+  MODULE:NEEDS[FeatureReliability]
+  {
+    name = Reliability
+    type = Antenna
+    title = Antenna
+    redundancy = Communication
+    repair = true
+    mtbf = 72576000 // 8y
+    extra_cost = 2.0
+    extra_mass = 1.0
+  }
+  MODULE
+  {
+    name = ModuleAnimationGroup
+    deployAnimationName = deploy
+    moduleType = Antenna
+  }
+
+  !MODULE[ModuleAnimateGeneric]:HAS[#animationName[deploy]] {}  
+}
+
+@PART[dish_deploy_S]:NEEDS[FeatureSignal]:FOR[Kerbalism]
+{
+  MODULE
+  {
+    name = Antenna
+    type = high_gain
+    cost = 0.2
+    dist = 2.5e10
+    rate = 0.032
+    // Distance decided based on default figures given in Kerbalism
+  }
+  MODULE:NEEDS[FeatureReliability]
+  {
+    name = Reliability
+    type = Antenna
+    title = Antenna
+    redundancy = Communication
+    repair = true
+    mtbf = 72576000 // 8y
+    extra_cost = 2.0
+    extra_mass = 1.0
+  }
+  MODULE
+  {
+    name = ModuleAnimationGroup
+    deployAnimationName = deploy
+    moduleType = Antenna
+  }
+
+  !MODULE[ModuleDeployableAntenna]:HAS[#animationName[deploy]] {}  
+}
+
+@PART[dish_deploy_S2]:NEEDS[FeatureSignal]:FOR[Kerbalism]
+{
+  MODULE
+  {
+    name = Antenna
+    type = high_gain
+    cost = 0.2
+    dist = 2.5e10
+    rate = 0.032
+    // Distance decided based on default figures given in Kerbalism
+  }
+  MODULE:NEEDS[FeatureReliability]
+  {
+    name = Reliability
+    type = Antenna
+    title = Antenna
+    redundancy = Communication
+    repair = true
+    mtbf = 72576000 // 8y
+    extra_cost = 2.0
+    extra_mass = 1.0
+  }
+  MODULE
+  {
+    name = ModuleAnimationGroup
+    deployAnimationName = deploy
+    moduleType = Antenna
+  }
+
+  !MODULE[ModuleDeployableAntenna]:HAS[#animationName[deploy]] {}  
+}
+
+@PART[dish_L]:NEEDS[FeatureSignal]:FOR[Kerbalism]
+{
+  MODULE
+  {
+    name = Antenna
+    type = high_gain
+    cost = 0.4
+    dist = 1e11
+    rate = 0.078
+    // Rate and cost decided based on flavor text: greater bandwith and is more efficient than the dish_quetzal
+  }
+  MODULE:NEEDS[FeatureReliability]
+  {
+    name = Reliability
+    type = Antenna
+    title = Antenna
+    redundancy = Communication
+    repair = true
+    mtbf = 72576000 // 8y
+    extra_cost = 2.0
+    extra_mass = 1.0
+  }
+}
+
+@PART[dish_quetzal]:NEEDS[FeatureSignal]:FOR[Kerbalism]
+{
+  MODULE
+  {
+    name = Antenna
+    type = high_gain
+    cost = 0.5
+    dist = 1e11
+    rate = 0.064
+    // Distance decided based on default figures given in Kerbalism
+  }
+  MODULE:NEEDS[FeatureReliability]
+  {
+    name = Reliability
+    type = Antenna
+    title = Antenna
+    redundancy = Communication
+    repair = true
+    mtbf = 72576000 // 8y
+    extra_cost = 2.0
+    extra_mass = 1.0
+  }
+}
+
+@PART[dish_S]:NEEDS[FeatureSignal]:FOR[Kerbalism]
+{
+  MODULE
+  {
+    name = Antenna
+    type = high_gain
+    cost = 0.33
+    dist = 5e10
+    rate = 0.032
+    // Distance decided based on default figures given in Kerbalism
+  }
+  MODULE:NEEDS[FeatureReliability]
+  {
+    name = Reliability
+    type = Antenna
+    title = Antenna
+    redundancy = Communication
+    repair = true
+    mtbf = 72576000 // 8y
+    extra_cost = 2.0
+    extra_mass = 1.0
+  }
+}
+
+@PART[dish_tatsujin]:NEEDS[FeatureSignal]:FOR[Kerbalism]
+{
+  MODULE
+  {
+    name = Antenna
+    type = high_gain
+    cost = 0.2
+    dist = 2.5e10
+    rate = 0.032
+    // Distance decided based on default figures given in Kerbalism
+  }
+  MODULE:NEEDS[FeatureReliability]
+  {
+    name = Reliability
+    type = Antenna
+    title = Antenna
+    redundancy = Communication
+    repair = true
+    mtbf = 72576000 // 8y
+    extra_cost = 2.0
+    extra_mass = 1.0
+  }
+}
+
+@PART[ca_landv_hga]:NEEDS[FeatureSignal]:FOR[Kerbalism]
+{
+  MODULE
+  {
+    name = Antenna
+    type = high_gain
+    cost = 0.2
+    dist = 2.5e10
+    rate = 0.032
+  }
+  MODULE:NEEDS[FeatureReliability]
+  {
+    name = Reliability
+    type = Antenna
+    title = Antenna
+    redundancy = Communication
+    repair = true
+    mtbf = 72576000 // 8y
+    extra_cost = 2.0
+    extra_mass = 1.0
+  }
+}
+
+@PART[ca_landv_omni]:NEEDS[FeatureSignal]:FOR[Kerbalism]
+{
+  MODULE
+  {
+    name = Antenna
+    type = high_gain
+    cost = 0.1
+    dist = 5e6
+    rate = 0.016
+  }
+  MODULE:NEEDS[FeatureReliability]
+  {
+    name = Reliability
+    type = Antenna
+    title = Antenna
+    redundancy = Communication
+    repair = true
+    mtbf = 72576000 // 8y
+    extra_cost = 2.0
+    extra_mass = 1.0
+  }
+}
+
+@PART[ca_vor_dish]:NEEDS[FeatureSignal]:FOR[Kerbalism]
+{
+  MODULE
+  {
+    name = Antenna
+    type = high_gain
+    cost = 0.33
+    dist = 5e10
+    rate = 0.064
+    // Distance decided based on default figures given in Kerbalism
+  }
+  MODULE:NEEDS[FeatureReliability]
+  {
+    name = Reliability
+    type = Antenna
+    title = Antenna
+    redundancy = Communication
+    repair = true
+    mtbf = 72576000 // 8y
+    extra_cost = 2.0
+    extra_mass = 0.5
+  }
+}
+
+@PART[ca_vor_comm]:NEEDS[FeatureSignal]:FOR[Kerbalism]
+{
+  MODULE
+  {
+    name = Antenna
+    type = low_gain
+    cost = 0.1
+    dist = 5e6
+    rate = 0.016
+    // Distance decided based on default figures given in Kerbalism
+  }
+  MODULE:NEEDS[FeatureReliability]
+  {
+    name = Reliability
+    type = Antenna
+    title = Antenna
+    redundancy = Communication
+    repair = true
+    mtbf = 72576000 // 8y
+    extra_cost = 2.0
+    extra_mass = 0.5
+  }
+}
+
+@PART[ca_vor_comm]:NEEDS[FeatureSignal]:FOR[Kerbalism]
+{
+  MODULE
+  {
+    name = Antenna
+    type = low_gain
+    cost = 0.1
+    dist = 5e6
+    rate = 0.016
+    // Distance decided based on default figures given in Kerbalism
+  }
+  MODULE:NEEDS[FeatureReliability]
+  {
+    name = Reliability
+    type = Antenna
+    title = Antenna
+    redundancy = Communication
+    repair = true
+    mtbf = 72576000 // 8y
+    extra_cost = 2.0
+    extra_mass = 0.5
+  }
+}
+
+// ============================================================================
+// Embedded antennas
+// by dieDoktor
+// ============================================================================
+
+@PART[ca_fom_lander]:NEEDS[FeatureSignal]:FOR[Kerbalism]
+{
+  MODULE
+  {
+    name = Antenna
+    type = low_gain
+    cost = 0.1
+    dist = 2e6
+    rate = 0.008
+  }
+
+  MODULE:NEEDS[FeatureReliability]
+  {
+    name = Reliability
+    type = Antenna
+    title = Antenna
+    redundancy = Communication
+    repair = Engineer
+    mtbf = 72576000 // 8y
+    extra_cost = 2.0
+    extra_mass = 0.5
+  }
+}


### PR DESCRIPTION
Create support for Coatl Aerospace Probes Plus! as discussed in #128. This PR covers all of the stand-alone antennas and the singular embedded antenna. 