### PR TITLE
No more H2 and O2 dumping during electrolysis

### DIFF
--- a/GameData/Kerbalism/Profiles/Default.cfg
+++ b/GameData/Kerbalism/Profiles/Default.cfg
@@ -277,6 +277,7 @@ Profile
     input = Water@0.0008043014
     output = Hydrogen@1.0
     output = Oxygen@0.5065967706
+    dump = false
   }
 
   Process


### PR DESCRIPTION
When hydrogen or oxygen tanks are full now the electrolysis should stop in order to avoid unnecessary water disintegration.