### PR TITLE
Smelting ore in order to create shielding

### DIFF
--- a/GameData/Kerbalism/Profiles/Default.cfg
+++ b/GameData/Kerbalism/Profiles/Default.cfg
@@ -232,6 +232,16 @@ Profile
 
   Process
   {
+    name = ore smelter
+    modifier = _OreSmelter
+    input = ElectricCharge@1.2
+    input = Ore@0.00010926
+    output = Shielding@0.0000003847183
+    dump = false
+  }
+
+  Process
+  {
     name = atmo leaks
     modifier = surface,breathable
     input = Atmosphere@0.000000148
@@ -960,6 +970,14 @@ Profile
   MODULE
   {
     name = ProcessController
+    resource = _OreSmelter
+    title = Ore smelter
+    capacity = 1
+  }
+
+  MODULE
+  {
+    name = ProcessController
     resource = _Anthraquinone
     title = Anthraquinone process
     capacity = 1
@@ -1067,6 +1085,20 @@ Profile
         type = ProcessController
         id_field = resource
         id_value = _WasteCompressor
+      }
+    }
+
+    SETUP
+    {
+      name = Ore Smelter
+      desc = Process <b>Ore</b> to extract metal, for use in radiation shielding.
+      tech = precisionEngineering
+
+      MODULE
+      {
+        type = ProcessController
+        id_field = resource
+        id_value = _OreSmelter
       }
     }
 
@@ -1483,6 +1515,13 @@ RESOURCE_DEFINITION
 RESOURCE_DEFINITION
 {
   name = _WasteCompressor
+  density = 0.0
+  isVisible = false
+}
+
+RESOURCE_DEFINITION
+{
+  name = _OreSmelter
   density = 0.0
   isVisible = false
 }


### PR DESCRIPTION
Smelting ore in order to produce shielding seems more reasonable for a base than using pressed poo. :)
I kept the same conversion rate of the Waste Compressor. Let me know what you think.