### PR TITLE
Fixed lead density

### DIFF
--- a/GameData/Kerbalism/System/Resources.cfg
+++ b/GameData/Kerbalism/System/Resources.cfg
@@ -29,7 +29,7 @@ RESOURCE_DEFINITION
 RESOURCE_DEFINITION
 {
   name = Shielding
-  density = 0.213             // 20mm of lead on a surface = 20L of lead per m^2 = 20 x 10.65kg = 0.213T
+  density = 0.2268            // 20mm of lead on a surface = 20L of lead per m^2 = 20 x 11.34kg = 0.2268T
   unitCost = 0.0
   flowMode = ALL_VESSEL
   transfer = NONE


### PR DESCRIPTION
10.65 kg/dm^3 is the density of liquid lead... and I guess that even Jeb would be worried about a melted lead envelope around him. :)
The real density of solid lead is 11.34 kg/dm^3.